### PR TITLE
Ensure 404 page when generating gh pages.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "ng lint",
     "e2e": "ng e2e",
     "build:prod": "npm run check && ng build --prod",
-    "build-gh-pages": "npm run set-version && npm run build:prod",
+    "build-gh-pages": "npm run set-version && npm run build:prod && cp dist/index.html dist/404.html",
     "set-version": "node ./src/version-generator.js",
     "release": "standard-version",
     "check": "node ./scripts/checkTemplatesFormat.js"


### PR DESCRIPTION
### Motivation

Which issue does this fix? Fixes #56

Review: I have used Unix `cp` command because GitHub pages are being used in that environment. If you need me to install some dev npm package that is cross-platform - I can do that.

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Tested locally.
